### PR TITLE
Fix caching configuration for Go projects

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,7 @@ ENV VIRTUALENV_READ_ONLY_APP_DATA=1
 
 ARG GO=1.15.4
 ARG GO_SHA256=eb61005f0b932c93b424a3a4eaa67d72196c79129d9a3ea8578047683e2c80d5
-ENV PATH=/opt/go/bin:$PATH
+ENV PATH=/opt/go/bin:$PATH XDG_CACHE_HOME=/tmp/cache GOFLAGS=-modcacherw
 RUN : \
     && mkdir -p /opt \
     && curl --location --silent --output go.tgz https://golang.org/dl/go${GO}.linux-amd64.tar.gz \

--- a/bin/test
+++ b/bin/test
@@ -125,8 +125,57 @@ def test_can_install_ffi_gem(tag: str) -> None:
     ))
 
 
-def test_can_run_go(tag: str) -> None:
-    subprocess.check_call(('docker', 'run', '--rm', tag, 'go', 'version'))
+GO_HOOK = '''\
+repos:
+-   repo: https://github.com/golangci/golangci-lint
+    rev: v1.33.0
+    hooks:
+    -   id: golangci-lint
+'''
+
+GOLANGCI_LINT_CONFIG = '''\
+linters:
+  disable-all: true
+  enable:
+    - gofmt
+run:
+  deadline: 30s
+'''
+
+
+def test_can_run_go_hook(tag: str, pc: str, podman: bool) -> None:
+    userns = ('--userns=keep-id',) if podman else ()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        subprocess.check_call(('git', 'init', tmpdir))
+        with open(os.path.join(tmpdir, '.pre-commit-config.yaml'), 'w') as f:
+            f.write(GO_HOOK)
+        with open(os.path.join(tmpdir, '.golangci.yml'), 'w') as f:
+            f.write(GOLANGCI_LINT_CONFIG)
+        with open(os.path.join(tmpdir, 'pkg.go'), 'w') as f:
+            f.write('package somepkg\n')
+        with open(os.path.join(tmpdir, 'go.mod'), 'w') as f:
+            f.write('module github.com/example/mod\n\ngo 1.15\n')
+        subprocess.check_call(('git', '-C', tmpdir, 'add', '.'))
+
+        subprocess.check_call((
+            'docker', 'run', '--rm',
+            '--user', f'{os.getuid()}:{os.getgid()}',
+            *userns,
+            '--volume', f'{tmpdir}:/git:ro',
+            '--volume', f'{pc}:/pc:rw',
+            '--workdir', '/git',
+            tag, 'python3', '-mpre_commit', 'install-hooks',
+        ))
+        subprocess.check_call((
+            'docker', 'run', '--rm',
+            '--user', f'{os.getuid()}:{os.getgid()}',
+            *userns,
+            '--volume', f'{tmpdir}:/git:rw',
+            '--volume', f'{pc}:/pc:ro',
+            '--workdir', '/git',
+            tag, 'python3', '-mpre_commit',
+            'run', '--all-files', '--show-diff-on-failure',
+        ))
 
 
 def main() -> int:
@@ -146,8 +195,8 @@ def main() -> int:
         test_can_run_node_hook(args.tag, pc, podman=args.podman)
         print(' can install ffi gem '.center(79, '='), flush=True)
         test_can_install_ffi_gem(args.tag)
-        print(' can run go '.center(79, '='), flush=True)
-        test_can_run_go(args.tag)
+        print(' can run go hooks '.center(79, '='), flush=True)
+        test_can_run_go_hook(args.tag, pc, podman=args.podman)
 
     return 0
 


### PR DESCRIPTION
That should fix the behavior in which the default GOCACHE isn't writable
in pre-commit.ci, because GOCACHE defaults to $HOME/.cache/go-build on
Linux, and $HOME ins't writable. Setting it to /tmp is kind of a dirty
trick, but I figure pre-commit doesn't really care about GOCACHE since
it caches the $GOPATH anyways? (Alternatively we can have pre-commit
cache $GOCACHE too?).

This also sets GOFLAGS to modify Go's default behavior when fetching
modules locally: pre-commit run a rmtree at the end of the process, and
Go's default behavior is to create the modcache in read-only mode, which
causes rmtree to fail. By setting -modcacherw, we tell Go to create
modcache in read-write mode.