### PR TITLE
Add rust support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,4 +87,22 @@ RUN : \
     && rm -rf /opt/go/doc /opt/go/test \
     && rm go.tgz
 
+ARG RUST=1.48.0
+ARG RUSTUP_SHA256=ee7ade44063c96c6a37012cc599cb560dce95205c86d17b247c726d2285b230c
+ARG RUSTUP_VERSION=1.23.0
+ENV \
+    CARGO_HOME=/opt/rust/cargo \
+    RUSTUP_HOME=/opt/rust/rustup \
+    PATH=/opt/rust/cargo/bin:$PATH
+RUN : \
+    && rustArch='x86_64-unknown-linux-gnu' \
+    && curl --silent --location --output rustup-init "https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/${rustArch}/rustup-init" \
+    && echo "${RUSTUP_SHA256} rustup-init" | sha256sum --check \
+    && chmod +x rustup-init \
+    && ./rustup-init -y --profile minimal --no-modify-path --default-toolchain "$RUST" --default-host "$rustArch" \
+    && rm -rf rustup-init \
+    && rustup component add clippy rustfmt \
+    && :
+ENV CARGO_HOME=/tmp/cargo/home
+
 ENTRYPOINT ["dumb-init", "--"]

--- a/bin/_info
+++ b/bin/_info
@@ -89,6 +89,14 @@ def main() -> int:
     print()
     with _console():
         _call('ruby', '--version')
+    print()
+
+    print('## rust')
+    print()
+    with _console():
+        _call('cargo', '--version')
+        print()
+        _call('rustc', '--version')
 
     return 0
 

--- a/bin/test
+++ b/bin/test
@@ -178,6 +178,59 @@ def test_can_run_go_hook(tag: str, pc: str, podman: bool) -> None:
         ))
 
 
+RUST_HOOK = '''\
+repos:
+-   repo: local
+    hooks:
+    -   id: rust-local
+        name: rust-local
+        language: rust
+        entry: shellharden
+        types: [rust]
+        additional_dependencies: [cli:shellharden:3.1.0]
+'''
+
+CARGO_TOML = '''\
+[package]
+name = "testing"
+version = "0.1.0"
+'''
+
+
+def test_can_run_rust_hook(tag: str, pc: str, podman: bool) -> None:
+    userns = ('--userns=keep-id',) if podman else ()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        subprocess.check_call(('git', 'init', tmpdir))
+        with open(os.path.join(tmpdir, '.pre-commit-config.yaml'), 'w') as f:
+            f.write(RUST_HOOK)
+        with open(os.path.join(tmpdir, 'Cargo.toml'), 'w') as f:
+            f.write(CARGO_TOML)
+        os.mkdir(os.path.join(tmpdir, 'src'))
+        with open(os.path.join(tmpdir, 'src', 'main.rs'), 'w') as f:
+            f.write('fn main() {}')
+        subprocess.check_call(('git', '-C', tmpdir, 'add', '.'))
+
+        subprocess.check_call((
+            'docker', 'run', '--rm',
+            '--user', f'{os.getuid()}:{os.getgid()}',
+            *userns,
+            '--volume', f'{tmpdir}:/git:ro',
+            '--volume', f'{pc}:/pc:rw',
+            '--workdir', '/git',
+            tag, 'python3', '-mpre_commit', 'install-hooks',
+        ))
+        subprocess.check_call((
+            'docker', 'run', '--rm',
+            '--user', f'{os.getuid()}:{os.getgid()}',
+            *userns,
+            '--volume', f'{tmpdir}:/git:rw',
+            '--volume', f'{pc}:/pc:ro',
+            '--workdir', '/git',
+            tag, 'python3', '-mpre_commit',
+            'run', '--all-files', '--show-diff-on-failure',
+        ))
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('--podman', action='store_true')
@@ -197,6 +250,8 @@ def main() -> int:
         test_can_install_ffi_gem(args.tag)
         print(' can run go hooks '.center(79, '='), flush=True)
         test_can_run_go_hook(args.tag, pc, podman=args.podman)
+        print(' can run rust hooks '.center(79, '='), flush=True)
+        test_can_run_rust_hook(args.tag, pc, podman=args.podman)
 
     return 0
 


### PR DESCRIPTION
I mostly followed the steps from the [official buster image](https://github.com/rust-lang/docker-rust/blob/master/1.48.0/buster/Dockerfile). Besides the minimal profile I added `rustfmt` and `clippy` as I'm not sure they can be installed properly through additional dependencies. Adding rust toolchain increases the image size by `~45%`.