### PR TITLE
Add docker and docker_image support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -103,4 +103,15 @@ RUN : \
     && :
 ENV CARGO_HOME=/tmp/cargo/home
 
+RUN : \
+    && . /etc/lsb-release \
+    && curl -sSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
+    && echo deb https://download.docker.com/linux/ubuntu $DISTRIB_CODENAME stable > /etc/apt/sources.list.d/docker.list \
+    && apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        docker-ce-cli \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && :
+
 ENTRYPOINT ["dumb-init", "--"]

--- a/bin/_info
+++ b/bin/_info
@@ -99,6 +99,12 @@ def main() -> int:
         _call('cargo', '--version')
         print()
         _call('rustc', '--version')
+    print()
+
+    print('## docker')
+    print()
+    with _console():
+        _call('docker', '--version')
 
     return 0
 

--- a/bin/test
+++ b/bin/test
@@ -2,9 +2,10 @@
 from __future__ import annotations
 
 import argparse
-import os.path
+import os
 import subprocess
 import tempfile
+import time
 
 
 PYTHON_HOOKS = '''\
@@ -233,6 +234,261 @@ def test_can_run_rust_hook(tag: str, pc: str, podman: bool) -> None:
         ))
 
 
+HADOLINT_DOCKERFILE = '''\
+FROM hadolint/hadolint:latest-alpine
+'''
+
+DOCKER_REPO_HOOK = '''\
+-   id: hadolint-docker
+    name: hadolint (via Docker)
+    language: docker
+    entry: hadolint
+    types: [dockerfile]
+'''
+
+DOCKER_HOOK = '''\
+repos:
+-   repo: /git
+    rev: v1.0
+    hooks:
+    -   id: hadolint-docker
+'''
+
+DOCKER_IMAGE_HOOK = '''\
+repos:
+-   repo: local
+    hooks:
+    -   id: hadolint-docker-image
+        name: hadolint (via Docker image)
+        language: docker_image
+        entry: hadolint/hadolint:latest-alpine hadolint
+        types: [dockerfile]
+'''
+
+
+def test_can_run_docker_hook(tag: str, pc: str, podman: bool) -> None:
+    userns = ('--userns=keep-id',) if podman else ()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        subprocess.check_call(('git', 'init', tmpdir))
+        with open(os.path.join(tmpdir, '.pre-commit-config.yaml'), 'w') as f:
+            f.write(DOCKER_HOOK)
+        with open(os.path.join(tmpdir, '.pre-commit-hooks.yaml'), 'w') as f:
+            f.write(DOCKER_REPO_HOOK)
+        with open(os.path.join(tmpdir, 'Dockerfile'), 'w') as f:
+            f.write(HADOLINT_DOCKERFILE)
+        subprocess.check_call(('git', '-C', tmpdir, 'add', '.'))
+        subprocess.check_call(
+            ('git', '-C', tmpdir, 'commit', '-m', 'Initial commit'),
+        )
+        subprocess.check_call(
+            ('git', '-C', tmpdir, 'tag', '-m', 'v1.0', 'v1.0'),
+        )
+
+        docker_gid = os.stat('/var/run/docker.sock').st_gid
+        subprocess.check_call((
+            'docker', 'run', '--rm',
+            '--user', f'{os.getuid()}:{os.getgid()}',
+            '--group-add', f'{docker_gid}',
+            *userns,
+            '--volume', f'{tmpdir}:/git:ro',
+            '--volume', f'{pc}:/pc:rw',
+            '--volume', '/var/run/docker.sock:/var/run/docker.sock',
+            '--workdir', '/git',
+            tag, 'python3', '-mpre_commit', 'install-hooks',
+        ))
+        subprocess.check_call((
+            'docker', 'run', '--rm',
+            '--user', f'{os.getuid()}:{os.getgid()}',
+            '--group-add', f'{docker_gid}',
+            *userns,
+            '--volume', f'{tmpdir}:{tmpdir}:rw',
+            '--volume', f'{pc}:/pc:ro',
+            '--volume', '/var/run/docker.sock:/var/run/docker.sock',
+            '--workdir', f'{tmpdir}',
+            tag, 'python3', '-mpre_commit',
+            'run', '--all-files', '--show-diff-on-failure',
+        ))
+
+
+def test_can_run_docker_image_hook(tag: str, pc: str, podman: bool) -> None:
+    userns = ('--userns=keep-id',) if podman else ()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        subprocess.check_call(('git', 'init', tmpdir))
+        with open(os.path.join(tmpdir, '.pre-commit-config.yaml'), 'w') as f:
+            f.write(DOCKER_IMAGE_HOOK)
+        with open(os.path.join(tmpdir, 'Dockerfile'), 'w') as f:
+            f.write(HADOLINT_DOCKERFILE)
+        subprocess.check_call(('git', '-C', tmpdir, 'add', '.'))
+
+        docker_gid = os.stat('/var/run/docker.sock').st_gid
+        subprocess.check_call((
+            'docker', 'run', '--rm',
+            '--user', f'{os.getuid()}:{os.getgid()}',
+            '--group-add', f'{docker_gid}',
+            *userns,
+            '--volume', f'{tmpdir}:/git:ro',
+            '--volume', f'{pc}:/pc:rw',
+            '--volume', '/var/run/docker.sock:/var/run/docker.sock',
+            '--workdir', '/git',
+            tag, 'python3', '-mpre_commit', 'install-hooks',
+        ))
+        subprocess.check_call((
+            'docker', 'run', '--rm',
+            '--user', f'{os.getuid()}:{os.getgid()}',
+            '--group-add', f'{docker_gid}',
+            *userns,
+            '--volume', f'{tmpdir}:{tmpdir}:rw',
+            '--volume', f'{pc}:/pc:ro',
+            '--volume', '/var/run/docker.sock:/var/run/docker.sock',
+            '--workdir', f'{tmpdir}',
+            tag, 'python3', '-mpre_commit',
+            'run', '--all-files', '--show-diff-on-failure',
+        ))
+
+
+def test_can_run_dind_hook(tag: str, pc: str, podman: bool) -> None:
+    userns = ('--userns=keep-id',) if podman else ()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        subprocess.check_call(('git', 'init', tmpdir))
+        with open(os.path.join(tmpdir, '.pre-commit-config.yaml'), 'w') as f:
+            f.write(DOCKER_HOOK)
+        with open(os.path.join(tmpdir, '.pre-commit-hooks.yaml'), 'w') as f:
+            f.write(DOCKER_REPO_HOOK)
+        with open(os.path.join(tmpdir, 'Dockerfile'), 'w') as f:
+            f.write(HADOLINT_DOCKERFILE)
+        subprocess.check_call(('git', '-C', tmpdir, 'add', '.'))
+        subprocess.check_call(
+            ('git', '-C', tmpdir, 'commit', '-m', 'Initial commit'),
+        )
+        subprocess.check_call(
+            ('git', '-C', tmpdir, 'tag', '-m', 'v1.0', 'v1.0'),
+        )
+
+        try:
+            subprocess.check_call(
+                ('docker', 'network', 'create', 'docker-dind'),
+            )
+            subprocess.check_call((
+                'docker', 'run', '--rm',
+                '--detach', '--privileged',
+                '--name', 'docker-dind',
+                '--env', 'DOCKER_TLS_CERTDIR=/certs',
+                '--network', 'docker-dind',
+                '--network-alias', 'docker',
+                '--volume', f'{tmpdir}:/git',
+                '--volume', 'docker-certs:/certs/client',
+                'docker:dind',
+            ))
+            for _ in range(60):
+                try:
+                    subprocess.check_call((
+                        'docker', 'exec', 'docker-dind',
+                        'nc', '-z', '127.0.0.1', '2376',
+                    ))
+                    break
+                except subprocess.CalledProcessError:
+                    print('Waiting for Docker-in-Docker to spin up...')
+                    time.sleep(1)
+            subprocess.check_call((
+                'docker', 'run', '--rm',
+                '--user', f'{os.getuid()}:{os.getgid()}',
+                *userns,
+                '--env', 'DOCKER_HOST=tcp://docker:2376',
+                '--env', 'DOCKER_CERT_PATH=/certs/client',
+                '--env', 'DOCKER_TLS_VERIFY=1',
+                '--network', 'docker-dind',
+                '--volume', f'{tmpdir}:/git:ro',
+                '--volume', f'{pc}:/pc:rw',
+                '--volume', 'docker-certs:/certs/client:ro',
+                '--workdir', '/git',
+                tag, 'python3', '-mpre_commit', 'install-hooks',
+            ))
+            subprocess.check_call((
+                'docker', 'run', '--rm',
+                '--user', f'{os.getuid()}:{os.getgid()}',
+                *userns,
+                '--env', 'DOCKER_HOST=tcp://docker:2376',
+                '--env', 'DOCKER_CERT_PATH=/certs/client',
+                '--env', 'DOCKER_TLS_VERIFY=1',
+                '--network', 'docker-dind',
+                '--volume', f'{tmpdir}:/git:rw',
+                '--volume', f'{pc}:/pc:ro',
+                '--volume', 'docker-certs:/certs/client:ro',
+                '--workdir', '/git',
+                tag, 'python3', '-mpre_commit',
+                'run', '--all-files', '--show-diff-on-failure',
+            ))
+        finally:
+            subprocess.check_call(('docker', 'stop', 'docker-dind'))
+            subprocess.check_call(('docker', 'volume', 'rm', 'docker-certs'))
+            subprocess.check_call(('docker', 'network', 'rm', 'docker-dind'))
+
+
+def test_can_run_dind_image_hook(tag: str, pc: str, podman: bool) -> None:
+    userns = ('--userns=keep-id',) if podman else ()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        subprocess.check_call(('git', 'init', tmpdir))
+        with open(os.path.join(tmpdir, '.pre-commit-config.yaml'), 'w') as f:
+            f.write(DOCKER_IMAGE_HOOK)
+        with open(os.path.join(tmpdir, 'Dockerfile'), 'w') as f:
+            f.write(HADOLINT_DOCKERFILE)
+        subprocess.check_call(('git', '-C', tmpdir, 'add', '.'))
+
+        try:
+            subprocess.check_call(
+                ('docker', 'network', 'create', 'docker-dind'),
+            )
+            subprocess.check_call((
+                'docker', 'run', '--rm',
+                '--detach', '--privileged',
+                '--name', 'docker-dind',
+                '--env', 'DOCKER_TLS_CERTDIR=/certs',
+                '--network', 'docker-dind',
+                '--network-alias', 'docker',
+                '--volume', f'{tmpdir}:/git',
+                '--volume', 'docker-certs:/certs/client',
+                'docker:dind',
+            ))
+            for _ in range(60):
+                try:
+                    subprocess.check_call((
+                        'docker', 'exec', 'docker-dind',
+                        'nc', '-z', '127.0.0.1', '2376',
+                    ))
+                    break
+                except subprocess.CalledProcessError:
+                    print('Waiting for Docker-in-Docker to spin up...')
+                    time.sleep(1)
+            subprocess.check_call((
+                'docker', 'run', '--rm',
+                '--user', f'{os.getuid()}:{os.getgid()}',
+                *userns,
+                '--volume', f'{tmpdir}:/git:ro',
+                '--volume', f'{pc}:/pc:rw',
+                '--workdir', '/git',
+                tag, 'python3', '-mpre_commit', 'install-hooks',
+            ))
+            subprocess.check_call((
+                'docker', 'run', '--rm',
+                '--user', f'{os.getuid()}:{os.getgid()}',
+                *userns,
+                '--env', 'DOCKER_HOST=tcp://docker:2376',
+                '--env', 'DOCKER_CERT_PATH=/certs/client',
+                '--env', 'DOCKER_TLS_VERIFY=1',
+                '--network', 'docker-dind',
+                '--volume', f'{tmpdir}:/git:rw',
+                '--volume', f'{pc}:/pc:ro',
+                '--volume', 'docker-certs:/certs/client:ro',
+                '--workdir', '/git',
+                tag, 'python3', '-mpre_commit',
+                'run', '--all-files', '--show-diff-on-failure',
+            ))
+        finally:
+            subprocess.check_call(('docker', 'stop', 'docker-dind'))
+            subprocess.check_call(('docker', 'volume', 'rm', 'docker-certs'))
+            subprocess.check_call(('docker', 'network', 'rm', 'docker-dind'))
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('--podman', action='store_true')
@@ -254,6 +510,14 @@ def main() -> int:
         test_can_run_go_hook(args.tag, pc, podman=args.podman)
         print(' can run rust hooks '.center(79, '='), flush=True)
         test_can_run_rust_hook(args.tag, pc, podman=args.podman)
+        print(' can run docker hook '.center(79, '='), flush=True)
+        test_can_run_docker_hook(args.tag, pc, podman=args.podman)
+        print(' can run docker image hook '.center(79, '='), flush=True)
+        test_can_run_docker_image_hook(args.tag, pc, podman=args.podman)
+        print(' can run dind hook '.center(79, '='), flush=True)
+        test_can_run_dind_hook(args.tag, pc, podman=args.podman)
+        print(' can run dind image hook '.center(79, '='), flush=True)
+        test_can_run_dind_image_hook(args.tag, pc, podman=args.podman)
 
     return 0
 

--- a/bin/test
+++ b/bin/test
@@ -278,10 +278,13 @@ def test_can_run_docker_hook(tag: str, pc: str, podman: bool) -> None:
             f.write(HADOLINT_DOCKERFILE)
         subprocess.check_call(('git', '-C', tmpdir, 'add', '.'))
         subprocess.check_call(
-            ('git', '-C', tmpdir, 'commit', '-m', 'Initial commit'),
+            (
+                'git', '-C', tmpdir, '-c', 'user.email=foo@bar.com',
+                'commit', '-m', 'Initial commit',
+            ),
         )
         subprocess.check_call(
-            ('git', '-C', tmpdir, 'tag', '-m', 'v1.0', 'v1.0'),
+            ('git', '-C', tmpdir, 'tag', 'v1.0'),
         )
 
         docker_gid = os.stat('/var/run/docker.sock').st_gid
@@ -358,10 +361,13 @@ def test_can_run_dind_hook(tag: str, pc: str, podman: bool) -> None:
             f.write(HADOLINT_DOCKERFILE)
         subprocess.check_call(('git', '-C', tmpdir, 'add', '.'))
         subprocess.check_call(
-            ('git', '-C', tmpdir, 'commit', '-m', 'Initial commit'),
+            (
+                'git', '-C', tmpdir, '-c', 'user.email=foo@bar.com',
+                'commit', '-m', 'Initial commit',
+            ),
         )
         subprocess.check_call(
-            ('git', '-C', tmpdir, 'tag', '-m', 'v1.0', 'v1.0'),
+            ('git', '-C', tmpdir, 'tag', 'v1.0'),
         )
 
         try:

--- a/bin/test
+++ b/bin/test
@@ -277,12 +277,10 @@ def test_can_run_docker_hook(tag: str, pc: str, podman: bool) -> None:
         with open(os.path.join(tmpdir, 'Dockerfile'), 'w') as f:
             f.write(HADOLINT_DOCKERFILE)
         subprocess.check_call(('git', '-C', tmpdir, 'add', '.'))
-        subprocess.check_call(
-            (
-                'git', '-C', tmpdir, '-c', 'user.email=foo@bar.com',
-                'commit', '-m', 'Initial commit',
-            ),
-        )
+        subprocess.check_call((
+            'git', '-C', tmpdir, '-c', 'user.name=bob',
+            '-c', 'user.email=foo@bar.com', 'commit', '-m', 'Initial commit',
+        ))
         subprocess.check_call(
             ('git', '-C', tmpdir, 'tag', 'v1.0'),
         )
@@ -360,12 +358,10 @@ def test_can_run_dind_hook(tag: str, pc: str, podman: bool) -> None:
         with open(os.path.join(tmpdir, 'Dockerfile'), 'w') as f:
             f.write(HADOLINT_DOCKERFILE)
         subprocess.check_call(('git', '-C', tmpdir, 'add', '.'))
-        subprocess.check_call(
-            (
-                'git', '-C', tmpdir, '-c', 'user.email=foo@bar.com',
-                'commit', '-m', 'Initial commit',
-            ),
-        )
+        subprocess.check_call((
+            'git', '-C', tmpdir, '-c', 'user.name=bob',
+            '-c', 'user.email=foo@bar.com', 'commit', '-m', 'Initial commit',
+        ))
         subprocess.check_call(
             ('git', '-C', tmpdir, 'tag', 'v1.0'),
         )


### PR DESCRIPTION
Given that pre-commit runs in a container, the following setups were
tested:
* Bind mounting the host's Docker socket (requires elevated permissions
for the user inside the container)
* Docker-in-Docker (requires elevated permissions for the container
acting as Docker host)

Podman support was not tested.