### PR TITLE
support R language

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN : \
         gcc \
         git \
         gnupg2 \
+        libblas3 \
         libc6 \
         libedit2 \
         libffi-dev \
@@ -19,6 +20,7 @@ RUN : \
         libgdiplus \
         libgssapi-krb5-2 \
         libicu66 \
+        liblapack3 \
         libssl1.1 \
         libstdc++6 \
         libxml2 \
@@ -184,4 +186,17 @@ RUN : \
     # https://github.com/dart-lang/sdk/issues/47093
     && chmod -R og+rX /opt/dart \
     && rm /tmp/dart.zip \
+    && :
+
+ENV \
+    PATH=/opt/r/bin/:$PATH \
+    RENV_CONFIG_CACHE_SYMLINKS=false \
+    RENV_PATHS_ROOT=/tmp/renv
+RUN : \
+    && echo 'lang: r' \
+    && curl --silent --location --output /tmp/r.tgz https://github.com/pre-commit-ci/runner-image/releases/download/ubuntu-20.04-r-4.0.2/r-4.0.2.tgz \
+    && echo 'f74f3227bbcb7f6464c0755441a2f0455fd6d2bde3c16ee8ef3302047f4e1eef /tmp/r.tgz' | sha256sum --check \
+    && mkdir /opt/r \
+    && tar -C /opt/r -xf /tmp/r.tgz \
+    && rm /tmp/r.tgz \
     && :

--- a/bin/_info
+++ b/bin/_info
@@ -98,6 +98,12 @@ def main() -> int:
         _call('npm', '--version')
     print()
 
+    print('## r')
+    print()
+    with _console():
+        _call('R', '--version')
+    print()
+
     print('## ruby')
     print()
     with _console():

--- a/bin/test
+++ b/bin/test
@@ -291,6 +291,28 @@ def test_can_run_dart_hook(tag: str, pc: str, podman: bool) -> None:
         _build_and_run(tag, tmpdir, pc, podman=podman)
 
 
+R_HOOK = '''\
+repos:
+-   repo: local
+    hooks:
+    -   id: r-local
+        name: r-local
+        language: r
+        entry: Rscript -e "glue::glue('1+1')"
+        additional_dependencies: [glue@1.4.2]
+'''
+
+
+def test_can_run_r_hook(tag: str, pc: str, podman: bool) -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        subprocess.check_call(('git', 'init', tmpdir))
+        with open(os.path.join(tmpdir, '.pre-commit-config.yaml'), 'w') as f:
+            f.write(R_HOOK)
+        subprocess.check_call(('git', '-C', tmpdir, 'add', '.'))
+
+        _build_and_run(tag, tmpdir, pc, podman=podman)
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('--podman', action='store_true')
@@ -319,11 +341,12 @@ def main() -> int:
         test_can_run_swift_hook(full_tag, pc, podman=args.podman)
         print(' can run dotnet hooks '.center(79, '='), flush=True)
         test_can_run_dotnet_hook(full_tag, pc, podman=args.podman)
-        print(' can run conda tools '.center(79, '='), flush=True)
+        print(' can run conda hooks '.center(79, '='), flush=True)
         test_can_run_conda_hook(full_tag, pc, podman=args.podman)
         print(' can run dart tools '.center(79, '='), flush=True)
         test_can_run_dart_hook(full_tag, pc, podman=args.podman)
-        return 0
+        print(' can run R hooks '.center(79, '='), flush=True)
+        test_can_run_r_hook(full_tag, pc, podman=args.podman)
 
     return 0
 


### PR DESCRIPTION
Closes #59. This is a first draft, let's see if CI passes. This installs R via the debian packaging system, with the default repos. For maximal compatibility, no version number is set. 

Installing R into a specific location is only possible when building from source, and that requires additional build dependencies like Fortran Compiler, Make etc. I assumed it's enough to locate the execution binary in `/opt/r`, so I just moved it there after installation.

The test I adapted from swift and rust.