### PR TITLE
Also disable global package cache for R

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -190,6 +190,7 @@ RUN : \
 
 ENV \
     PATH=/opt/r/bin/:$PATH \
+    RENV_CONFIG_CACHE_ENABLED=false \
     RENV_CONFIG_CACHE_SYMLINKS=false \
     RENV_PATHS_ROOT=/tmp/renv
 RUN : \


### PR DESCRIPTION
basically adding `RENV_CONFIG_CACHE_ENABLED=False`. I also tried to create the directory `/tmp/renv`, which is the specified cache root, but then it does not work anymore because of permission denied issues. Seems like the env variable to disable is not respected once it exists... :-/ 

Hence, not sure this is strictly better than the current master. Aims to close #93.