### PR TITLE
Add cmake build tool.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN : \
     && apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates \
+        cmake \
         curl \
         dumb-init \
         g++ \


### PR DESCRIPTION
I see that gcc and g++ are already supported and, thus, assume that compilation is a supported feature of pre-commit-ci. This PR adds `cmake` to support compilation of C/C++ projects that use that build system.

I'm requesting adding this because the LuaFormatter hook (which I'm trying to get added in the upstream project) expects cmake to exist. Here's a run on my Lua project where it failed because of the lack of cmake.

https://results.pre-commit.ci/run/github/407724074/1642562504.wkNZBIfBQ9SNsKHNJlCf8g