### PR TITLE
Add pypy3 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ RUN : \
     && echo deb http://ppa.launchpad.net/deadsnakes/ppa/ubuntu $DISTRIB_CODENAME main > /etc/apt/sources.list.d/deadsnakes.list \
     && apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        pypy3-dev \
         python3.7-dev \
         python3.7-distutils \
         python3.8-dev \

--- a/bin/_info
+++ b/bin/_info
@@ -54,6 +54,8 @@ def main() -> int:
         _call('python3.9', '--version', '--version')
         print()
         _call('python3.10', '--version', '--version')
+        print()
+        _call('pypy3', '--version', '--version')
     print()
 
     print('## conda')

--- a/build/seed-virtualenv-cache
+++ b/build/seed-virtualenv-cache
@@ -6,7 +6,7 @@ import re
 import shutil
 import subprocess
 
-PYTHON_RE = re.compile(r'^python(\d+(\.\d+)?)?$')
+PYTHON_RE = re.compile(r'^(python|pypy)(\d+(\.\d+)?)?$')
 
 
 def main() -> int:


### PR DESCRIPTION
Resolves: pre-commit-ci/issues#191

-----

I hope this is done correctly in case the original issue has merit, otherwise I apologise for taking up your time.

I took inspiration from an older commit (https://github.com/pre-commit-ci/runner-image/commit/bb1fe8e685f7f6ca15852f2ecd295b8062d024d0) and placed pypy3 on top to not break numbering as new python3.x packages are released.