### PR TITLE
Upgrade go to 1.22.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,8 +91,8 @@ ENV VIRTUALENV_READ_ONLY_APP_DATA=1
 # pre-commit.ci requires cross-user readonly `/src` repo access
 RUN git config --system --add safe.directory /src
 
-ARG GO=1.21.0
-ARG GO_SHA256=d0398903a16ba2232b389fb31032ddf57cac34efda306a0eebac34f0965a0742
+ARG GO=1.22.4
+ARG GO_SHA256=ba79d4526102575196273416239cca418a651e049c2b099f3159db85e7bade7d
 ENV PATH=/opt/go/bin:$PATH GOFLAGS=-modcacherw
 RUN : \
     && mkdir -p /opt \


### PR DESCRIPTION
Recently [terraform-docs](https://github.com/terraform-docs/terraform-docs/releases/tag/v0.18.0) raised their minimum Go version to `1.22.1`, which has caused some of my autoupdate PRs to fail:
```
build attempt 1...
    => error
    [INFO] Installing environment for https://github.com/terraform-docs/terraform-docs.
    [INFO] Once installed this environment will be reused.
    [INFO] This may take a few minutes...
    An unexpected error has occurred: CalledProcessError: command: ('/opt/go/bin/go', 'install', './...')
    return code: 1
    stdout: (none)
    stderr:
        go: downloading go1.22 (linux/amd64)
        go: download go1.22 for linux/amd64: toolchain not available
    Check the log at /pc/pre-commit.log
build attempt 2...
    => error
    [INFO] Installing environment for https://github.com/terraform-docs/terraform-docs.
    [INFO] Once installed this environment will be reused.
    [INFO] This may take a few minutes...
    An unexpected error has occurred: CalledProcessError: command: ('/opt/go/bin/go', 'install', './...')
    return code: 1
    stdout: (none)
    stderr:
        go: downloading go1.22 (linux/amd64)
        go: download go1.22 for linux/amd64: toolchain not available
    Check the log at /pc/pre-commit.log
```
I based this off #231, and collected the sha from [here](https://go.dev/dl/).