### PR TITLE
Update identify requirement to 2.6.19 to support pyproject filetype.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cfgv==3.5.0
 distlib==0.4.0
 filelock==3.20.0
-identify==2.6.15
+identify==2.6.19
 nodeenv==1.9.1
 platformdirs==4.5.0
 pre-commit==4.5.0


### PR DESCRIPTION
Fixes https://github.com/pre-commit-ci/issues/issues/265.
