### PR TITLE
Proper JULIA_DEPOT_PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -205,9 +205,7 @@ RUN : \
 
 ARG JULIA=1.12.6
 ARG JULIA_SHA256=bbabf3bef19421a9dbd24a767d807606ab85e444323b5a1c73ffe293fa3d079a
-ENV \
-    PATH=/opt/julia/bin:$PATH \
-    JULIA_DEPOT_PATH=/pc/julia_depot
+ENV PATH=/opt/julia/bin:$PATH
 RUN : \
     && echo 'lang: julia' \
     && julia_minor="${JULIA%.*}" \


### PR DESCRIPTION
This should fix the speed issues mentioned in https://github.com/pre-commit-ci/runner-image/pull/332#issuecomment-4580326217.

The explanation is [in the julia docs](https://docs.julialang.org/en/v1/manual/environment-variables/#JULIA_DEPOT_PATH):

> This allows easy overriding of the user depot, while still retaining access to resources that are bundled with Julia, like cache files, artifacts, etc. For example, to switch the user depot to /foo/bar use a trailing :
> ```
> export JULIA_DEPOT_PATH="/foo/bar:"
> ```
> All package operations, like cloning registries or installing packages, will now write to /foo/bar, but since the empty entry is expanded to the default system depot, any bundled resources will still be available. If you really only want to use the depot at /foo/bar, and not load any bundled resources, simply set the environment variable to /foo/bar without the trailing colon.
> 


We had inadvertently been "not load[ing] any bundled resources", requiring us to instantiate `Pkg` at hook install time, which took > 1.5 min. Now it is already instantiated and can be used instantaneously.

Tagging @asottile for review.